### PR TITLE
Fix log trimming bug

### DIFF
--- a/js/gameLogic.js
+++ b/js/gameLogic.js
@@ -534,7 +534,7 @@ export function logAction(message) {
   // Agregar el mensaje al log
   gameState.log.push(message);
   // si hay mas de 5, eliminar el mas antiguo
-  if (gameState.log.lenght > 5) {
+  if (gameState.log.length > 5) {
     gameState.log.shift();
   }
   // Actualizar la UI del log


### PR DESCRIPTION
## Summary
- fix typo preventing log trimming

## Testing
- `node -e "require('./js/gameLogic.js')"` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_683f49c997a8832ba8f30e6349c3d379